### PR TITLE
fix: hide image border when editor is not editable

### DIFF
--- a/src/registry/extensions/image.tsx
+++ b/src/registry/extensions/image.tsx
@@ -181,7 +181,7 @@ function TiptapImage(props: NodeViewProps) {
 			ref={nodeRef}
 			className={cn(
 				"relative flex flex-col rounded-md border-2 border-transparent",
-				selected ? "border-blue-300" : "",
+				selected && editor?.isEditable ? "border-blue-300" : "",
 				node.attrs.align === "left" && "left-0 -translate-x-0",
 				node.attrs.align === "center" && "left-1/2 -translate-x-1/2",
 				node.attrs.align === "right" && "left-full -translate-x-full",


### PR DESCRIPTION
## Description

When the editor is disabled, selecting an image should not have a border.


## Screenshots (if applicable)

Before

<img width="814" alt="image" src="https://github.com/user-attachments/assets/00f746a4-44f1-4653-a2c3-b5744eec905d">

After
<img width="1418" alt="image" src="https://github.com/user-attachments/assets/286bc195-4d33-469e-ae48-05c09490b378">

